### PR TITLE
#29 - Make loading models optional

### DIFF
--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -8,6 +8,4 @@ threads = 2
 
 raw_env = ["pos_model=pos","ner_model=ner","sentiment_model=en-sentiment"]
 
-debug = True
-
 preload_app = True


### PR DESCRIPTION
- Load the model on demand
- For the debug mode: 
    "python app_flair.py" loads all models by default, 
    "python app_flair.py --ner ner" loads only NER model and so on.
- For the Gunicorn: 
    "raw_env = ["pos_model=None","ner_model=None","sentiment_model=None"]" loads all models by default,
    "raw_env = ["pos_model=pos","ner_model=ner","sentiment_model=None"]" loads only POS and NER models and so on.